### PR TITLE
Remove and bump ci.yml duplicate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
-
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: 'itsmattkc/msvc420'
         path: msvc420


### PR DESCRIPTION
Tiny change that removes a duplicate in ci.yml. Also bumped the checkout to 4.x